### PR TITLE
Delete join message

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func challengeUser(m *tb.Message) {
 			if config.PrintSuccessAndFail == "show" {
 				bot.Edit(challengeMsg, config.AfterFailMessage)
 			} else if config.PrintSuccessAndFail == "del" {
+				bot.Delete(m)
 				bot.Delete(challengeMsg)
 			}
 


### PR DESCRIPTION
* This avoids the confusion if the bot has banned the user or not.